### PR TITLE
Add GitHub Models as a dedicated provider

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -194,6 +194,12 @@ def load_settings(profile_id: str = None):
                 "credentials": {
                     "api_key": ""
                 }
+            },
+            "github_models": {
+                "enabled": False,
+                "credentials": {
+                    "api_key": ""
+                }
             }
         }
     }
@@ -1114,7 +1120,7 @@ def validate_provider(provider_id: str, credentials: dict = Body(...)):
             print(f"[Validation] No API key found in settings")
         
         # For providers with dynamic discovery, use enhanced validation
-        providers_with_discovery = ["google", "openai", "mistral", "groq", "openrouter", "anthropic"]
+        providers_with_discovery = ["google", "openai", "mistral", "groq", "openrouter", "anthropic", "github_models"]
         
         if provider_id in providers_with_discovery and hasattr(provider, 'validate_credentials_and_list_models'):
             result = provider.validate_credentials_and_list_models(creds)

--- a/backend/model_providers/__init__.py
+++ b/backend/model_providers/__init__.py
@@ -11,6 +11,7 @@ from .ollama import OllamaProvider
 from .lmstudio import LMStudioProvider
 from .openai import OpenAIProvider
 from .anthropic import AnthropicProvider
+from .github_models import GitHubModelsProvider
 from .additional import (
     MistralProvider,
     GoogleProvider,
@@ -60,6 +61,7 @@ def _initialize_providers():
         LMStudioProvider(),
         OpenAIProvider(),
         AnthropicProvider(),
+        GitHubModelsProvider(),
         MistralProvider(),
         GoogleProvider(),
         GroqProvider(),

--- a/backend/model_providers/github_models.py
+++ b/backend/model_providers/github_models.py
@@ -1,0 +1,55 @@
+"""
+GitHub Models provider.
+
+Uses the GitHub Models API (https://models.inference.ai.azure.com),
+which is OpenAI-compatible and authenticated with a GitHub personal
+access token. Works with GitHub Copilot subscriptions and free accounts
+(subject to rate limits).
+"""
+
+from typing import Dict, Any, List
+from .base import Message, ChatResponse, ModelInfo
+from .openai import OpenAIProvider
+
+
+GITHUB_MODELS_BASE_URL = "https://models.inference.ai.azure.com"
+
+
+class GitHubModelsProvider(OpenAIProvider):
+    """Provider implementation for GitHub Models (OpenAI-compatible API)."""
+
+    def __init__(self):
+        super().__init__()
+        self._id = "github_models"
+        self._label = "GitHub Models"
+        self._default_model = "gpt-4o-mini"
+
+    def _with_base_url(self, credentials: Dict[str, Any]) -> Dict[str, Any]:
+        """Return credentials with the hardcoded GitHub Models base URL."""
+        creds = dict(credentials)
+        creds["base_url"] = GITHUB_MODELS_BASE_URL
+        return creds
+
+    def _get_client(self, credentials: Dict[str, Any]):
+        return super()._get_client(self._with_base_url(credentials))
+
+    def _list_models_raw(self, credentials: Dict[str, Any]):
+        return super()._list_models_raw(self._with_base_url(credentials))
+
+    def validate_credentials(self, credentials: Dict[str, Any]) -> bool:
+        return super().validate_credentials(self._with_base_url(credentials))
+
+    def validate_credentials_and_list_models(self, credentials: Dict[str, Any]) -> Dict[str, Any]:
+        return super().validate_credentials_and_list_models(self._with_base_url(credentials))
+
+    def list_models(self, credentials: Dict[str, Any]) -> List[ModelInfo]:
+        return super().list_models(self._with_base_url(credentials))
+
+    def chat(
+        self,
+        credentials: Dict[str, Any],
+        model: str,
+        messages: List[Message],
+        **kwargs,
+    ) -> ChatResponse:
+        return super().chat(self._with_base_url(credentials), model, messages, **kwargs)

--- a/backend/model_providers/github_models.py
+++ b/backend/model_providers/github_models.py
@@ -8,7 +8,7 @@ access token. Works with GitHub Copilot subscriptions and free accounts
 """
 
 from typing import Dict, Any, List
-from .base import Message, ChatResponse, ModelInfo
+from .base import BaseProvider, Message, ChatResponse, ModelInfo
 from .openai import OpenAIProvider
 
 
@@ -19,10 +19,16 @@ class GitHubModelsProvider(OpenAIProvider):
     """Provider implementation for GitHub Models (OpenAI-compatible API)."""
 
     def __init__(self):
-        super().__init__()
-        self._id = "github_models"
-        self._label = "GitHub Models"
-        self._default_model = "gpt-4o-mini"
+        # Call BaseProvider.__init__ directly to set provider identity without
+        # inheriting OpenAI's hardcoded id/label while still reusing all its logic.
+        BaseProvider.__init__(
+            self,
+            id="github_models",
+            label="GitHub Models",
+            default_model="gpt-4o-mini",
+            supports_streaming=True,
+            requires_api_key=True,
+        )
 
     def _with_base_url(self, credentials: Dict[str, Any]) -> Dict[str, Any]:
         """Return credentials with the hardcoded GitHub Models base URL."""

--- a/backend/model_providers/openai.py
+++ b/backend/model_providers/openai.py
@@ -5,6 +5,9 @@ Implements the ModelProvider interface for OpenAI's API, supporting
 GPT-4, GPT-3.5, and other OpenAI models.
 """
 
+import re
+import httpx
+from dataclasses import dataclass
 from typing import Dict, Any, List, Optional
 from .base import (
     BaseProvider, Message, ChatResponse, ModelInfo,
@@ -12,6 +15,12 @@ from .base import (
     ProviderRateLimitError, ProviderContextError,
     MessageAdapter, ParameterMapper
 )
+
+
+@dataclass
+class _ModelStub:
+    """Lightweight proxy for model entries returned by raw HTTP model list responses."""
+    id: str
 
 
 class OpenAIProvider(BaseProvider):
@@ -67,7 +76,6 @@ class OpenAIProvider(BaseProvider):
 
         azureml://registries/azure-openai/models/gpt-4o/versions/2 -> gpt-4o
         """
-        import re
         match = re.search(r'/models/([^/]+)/versions/', raw_id)
         if match:
             return match.group(1)
@@ -75,7 +83,6 @@ class OpenAIProvider(BaseProvider):
 
     def _list_models_raw(self, credentials: Dict[str, Any]):
         """Fetch models via raw HTTP for endpoints that don't follow OpenAI response format."""
-        import httpx
         base_url = credentials.get("base_url", "").rstrip("/")
         api_key = credentials.get("api_key", "")
         resp = httpx.get(
@@ -118,7 +125,7 @@ class OpenAIProvider(BaseProvider):
                 # Custom endpoint returned a plain list — fall back to raw HTTP
                 print(f"[OpenAI Provider] SDK parse failed, falling back to raw HTTP model fetch")
                 raw_items = self._list_models_raw(credentials)
-                raw_models = [type("M", (), {"id": m.get("id", m) if isinstance(m, dict) else m})() for m in raw_items]
+                raw_models = [_ModelStub(id=m.get("id", m) if isinstance(m, dict) else m) for m in raw_items]
 
             available_model_ids = {model.id for model in raw_models}
             
@@ -246,7 +253,7 @@ class OpenAIProvider(BaseProvider):
             except (AttributeError, TypeError):
                 print(f"[OpenAI Provider] SDK parse failed, falling back to raw HTTP model fetch")
                 raw_items = self._list_models_raw(credentials)
-                raw_models = [type("M", (), {"id": m.get("id", m) if isinstance(m, dict) else m})() for m in raw_items]
+                raw_models = [_ModelStub(id=m.get("id", m) if isinstance(m, dict) else m) for m in raw_items]
 
             # Define curated models we care about for academic use
             curated_models = {

--- a/backend/model_providers/openai.py
+++ b/backend/model_providers/openai.py
@@ -62,9 +62,44 @@ class OpenAIProvider(BaseProvider):
             else:
                 raise ProviderError(f"OpenAI validation failed: {str(e)}")
     
+    def _extract_model_id(self, raw_id: str) -> str:
+        """Extract a usable model name from Azure ML resource paths.
+
+        azureml://registries/azure-openai/models/gpt-4o/versions/2 -> gpt-4o
+        """
+        import re
+        match = re.search(r'/models/([^/]+)/versions/', raw_id)
+        if match:
+            return match.group(1)
+        return raw_id
+
+    def _list_models_raw(self, credentials: Dict[str, Any]):
+        """Fetch models via raw HTTP for endpoints that don't follow OpenAI response format."""
+        import httpx
+        base_url = credentials.get("base_url", "").rstrip("/")
+        api_key = credentials.get("api_key", "")
+        resp = httpx.get(
+            f"{base_url}/models",
+            headers={"Authorization": f"Bearer {api_key}"},
+            timeout=15,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        # Handle both {"data": [...]} and plain [...] responses
+        items = data if isinstance(data, list) else data.get("data", [])
+        # Normalize model IDs — replace Azure ML paths with simple names
+        normalized = []
+        for m in items:
+            if isinstance(m, dict):
+                raw_id = m.get("id", "")
+                m = dict(m)
+                m["id"] = self._extract_model_id(raw_id)
+            normalized.append(m)
+        return normalized
+
     def validate_credentials_and_list_models(self, credentials: Dict[str, Any]) -> Dict[str, Any]:
         """Validate credentials AND return available models dynamically.
-        
+
         Returns:
             {
                 "valid": bool,
@@ -75,9 +110,17 @@ class OpenAIProvider(BaseProvider):
         try:
             client = self._get_client(credentials)
             print(f"[OpenAI Provider] Fetching dynamic models via client.models.list()...")
-            
-            models_response = client.models.list()
-            available_model_ids = {model.id for model in models_response.data}
+
+            try:
+                models_response = client.models.list()
+                raw_models = list(models_response.data)
+            except (AttributeError, TypeError):
+                # Custom endpoint returned a plain list — fall back to raw HTTP
+                print(f"[OpenAI Provider] SDK parse failed, falling back to raw HTTP model fetch")
+                raw_items = self._list_models_raw(credentials)
+                raw_models = [type("M", (), {"id": m.get("id", m) if isinstance(m, dict) else m})() for m in raw_items]
+
+            available_model_ids = {model.id for model in raw_models}
             
             # Define curated models for academic use
             curated_models = {
@@ -133,16 +176,16 @@ class OpenAIProvider(BaseProvider):
                         description="Custom endpoint model",
                         context_length=None
                     )
-                    for model in models_response.data
+                    for model in raw_models
                 ]
-                
+
                 # Warn if no models found
                 if not models:
                     print(f"[OpenAI Provider] WARNING: Custom endpoint returned 0 models")
             else:
                 # For official OpenAI API, use curated list
                 models = [info for model_id, info in curated_models.items() if model_id in available_model_ids]
-                
+
                 # If no curated models found, include all GPT/o1 models
                 if not models:
                     models = [
@@ -152,7 +195,7 @@ class OpenAIProvider(BaseProvider):
                             description="OpenAI model",
                             context_length=None
                         )
-                        for model in models_response.data
+                        for model in raw_models
                         if "gpt" in model.id.lower() or "o1" in model.id.lower()
                     ]
                     
@@ -197,8 +240,14 @@ class OpenAIProvider(BaseProvider):
         try:
             client = self._get_client(credentials)
             # Get models from API
-            models_response = client.models.list()
-            
+            try:
+                models_response = client.models.list()
+                raw_models = list(models_response.data)
+            except (AttributeError, TypeError):
+                print(f"[OpenAI Provider] SDK parse failed, falling back to raw HTTP model fetch")
+                raw_items = self._list_models_raw(credentials)
+                raw_models = [type("M", (), {"id": m.get("id", m) if isinstance(m, dict) else m})() for m in raw_items]
+
             # Define curated models we care about for academic use
             curated_models = {
                 "gpt-4o": ModelInfo(
@@ -241,17 +290,17 @@ class OpenAIProvider(BaseProvider):
                         description="Custom endpoint model",
                         context_length=None
                     )
-                    for model in models_response.data
+                    for model in raw_models
                 ]
-                
+
                 # Warn if no models found from custom endpoint
                 if not result:
                     print(f"[OpenAI Provider] WARNING: Custom endpoint at {base_url} returned 0 models")
-                
+
                 return result
             else:
                 # For official OpenAI API, use curated list with filtering
-                available_model_ids = {model.id for model in models_response.data}
+                available_model_ids = {model.id for model in raw_models}
                 available_models = [
                     info for model_id, info in curated_models.items()
                     if model_id in available_model_ids
@@ -270,7 +319,7 @@ class OpenAIProvider(BaseProvider):
                             description=None,
                             context_length=None
                         )
-                        for model in models_response.data
+                        for model in raw_models
                         if "gpt" in model.id.lower()
                     ]
                     

--- a/frontend/src/contexts/SettingsContext.tsx
+++ b/frontend/src/contexts/SettingsContext.tsx
@@ -87,6 +87,10 @@ const defaultSettings: Settings = {
     openrouter: {
       enabled: false,
       credentials: { api_key: '' }
+    },
+    github_models: {
+      enabled: false,
+      credentials: { api_key: '' }
     }
   }
 };

--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -273,7 +273,7 @@ const Settings: React.FC = () => {
             {provider.requires_api_key && (
               <div className="settings-field">
                 <label className="settings-label" htmlFor={`${provider.id}-api-key`}>
-                  API Key
+                  {provider.id === 'github_models' ? 'GitHub Token' : 'API Key'}
                   {provider.id === 'google' && (
                     <span style={{ marginLeft: '8px', fontSize: '12px', color: '#ff5722', fontWeight: 'normal' }}>
                       (Unreliable)
@@ -297,7 +297,7 @@ const Settings: React.FC = () => {
                     onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                       handleProviderCredentialChange(provider.id, 'api_key', e.target.value)
                     }
-                    placeholder="Enter API key"
+                    placeholder={provider.id === 'github_models' ? 'Enter GitHub personal access token' : 'Enter API key'}
                     className="settings-input"
                     style={{ paddingRight: '40px' }}
                   />
@@ -319,9 +319,11 @@ const Settings: React.FC = () => {
                     )}
                   </button>
                 </div>
-                {['openai', 'mistral', 'groq', 'openrouter'].includes(provider.id) && (
+                {['openai', 'mistral', 'groq', 'openrouter', 'github_models'].includes(provider.id) && (
                   <p className="settings-helper-text">
-                    Models are automatically discovered from your API key when you test the connection.
+                    {provider.id === 'github_models'
+                      ? 'Generate a token at github.com/settings/tokens (no special scopes required). Works with GitHub Copilot subscriptions.'
+                      : 'Models are automatically discovered from your API key when you test the connection.'}
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## Summary

- Adds a dedicated **GitHub Models** provider for users with a GitHub Copilot subscription, replacing the workaround of manually configuring OpenAI with a custom endpoint
- The provider hardcodes `https://models.inference.ai.azure.com` so users only need to paste a GitHub personal access token — no base URL to figure out
- Labels the credential field "GitHub Token" (not "API Key") and includes a helper note linking to token generation
- Fixes the OpenAI provider for **any** custom OpenAI-compatible endpoint (LM Studio, Azure, proxies, etc.):
  - Adds a raw HTTP fallback for model listing when the SDK fails to parse non-standard responses (plain `[...]` arrays instead of `{"data":[...]}`)
  - Normalizes Azure ML resource path model IDs to usable names (`azureml://registries/.../models/gpt-4o/versions/2` → `gpt-4o`)

## Test plan

- [x] GitHub Models card appears in Settings → cloud tab
- [x] Entering a GitHub PAT and clicking "Save & Test" populates the model dropdown (gpt-4o, gpt-4o-mini, Llama, Mistral, etc.)
- [x] Sending a chat message returns a response with citations
- [ ] OpenAI provider is unaffected and still works independently
- [ ] Custom endpoint on OpenAI provider (e.g. LM Studio) correctly lists and uses models

🤖 Generated with [Claude Code](https://claude.com/claude-code)